### PR TITLE
Fixed TAGS_MAP != tag["name"] due to captalization

### DIFF
--- a/emp_stash_fill.py
+++ b/emp_stash_fill.py
@@ -487,14 +487,14 @@ def generate():
         for key in TAG_LISTS:
             if tag["name"] in TAG_LISTS[key]:
                 TAG_SETS[key].add(tag["name"])
-        emp_tag = TAGS_MAP.get(tag["name"])
+        emp_tag = TAGS_MAP.get(tag["name"].lower())
         if emp_tag is not None:
             tags.add(emp_tag)
         for parent in tag["parents"]:
             for key in TAG_LISTS:
                 if parent["name"] in TAG_LISTS[key]:
                     TAG_SETS[key].add(parent["name"])
-            emp_tag = TAGS_MAP.get(parent["name"])
+            emp_tag = TAGS_MAP.get(parent["name"].lower())
             if emp_tag is not None:
                 tags.add(emp_tag)
 


### PR DESCRIPTION
I don't know why, but TAGS_MAP = conf["empornium.tags"].to_dict() is changing the capitalization of [empornium.tags], i.e. Doddy Style > doggy style.

So when emp_tag = TAGS_MAP.get(tag["name"].lower()) tries to match a tag["name"] it can't find any.