### PR TITLE
Include title_template for best Whisparr compatibility

### DIFF
--- a/default.ini
+++ b/default.ini
@@ -7,6 +7,9 @@ torrent_directory = /torrents
 port = 9932
 # jinja template for title
 # see README.md for available variables
+# Uncomment this title for Whisparr compatibility
+#title_template = {{ studio|replace(' ', '')|replace('[^a-zA-Z0-9]', '') }} - {{ date.split('-')[0][-2:] }}.{{ date.split('-')[1] }}.{{ date.split('-')[2] }} - {{ title }} - {{performers|join(', ')}} - {{ codec }} - WEBDL - {{ resolution }}
+# Uncomment this title for Classic EMP template
 title_template = {% if studio %}[{{studio}}] {% endif %}{{performers|join(', ')}}{% if performers %} - {% endif %}{{title}} {% if date %}({{date}}){% endif %}[{{resolution}}]
 # Date format for title release - https://strftime.org/ for reference
 date_format = %y-%m-%d


### PR DESCRIPTION
Gives users an option if they desire their release title to be easily parsed for max compatibility with automation tools like Whisparr and Autobrr