### PR TITLE
Add support for deluge webapi

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -20,7 +20,7 @@ anon = false
 
 # [rtorrent]
 ## Hostname or IP address
-# host = "192.168.1.1"
+# host = "localhost"
 ## Port number
 # port = 8080
 ## Set to true for https
@@ -35,6 +35,19 @@ anon = false
 
 # [rtorrent.pathmaps]
 # "/stash-empornium/path" = "/rtorrent/path"
+
+# [deluge]
+## Hostname or IP address
+# host = "127.0.0.1"
+## Port number
+# port = 8112
+## Set to true for https
+# ssl = false
+## Password for API
+# password = "deluge"
+
+# [deluge.pathmaps]
+# "/stash-empornium/path" = "/deluge/path"
 
 #[redis]
 #host = "localhost"

--- a/utils/torrent/deluge.py
+++ b/utils/torrent/deluge.py
@@ -1,0 +1,98 @@
+from unittest import result
+from utils.torrent.torrentclient import TorrentClient
+from utils.paths import mapPath
+import os
+import requests
+
+class Deluge(TorrentClient):
+    url: str
+    password: str
+    cookies = None
+    host: str = ""
+    torrent_dir: str
+
+    def __init__(self, settings: dict) -> None:
+        super().__init__(settings)
+        ssl = settings["ssl"] if "ssl" in settings else False
+        if "port" in settings:
+            port = settings["port"]
+        else:
+            port = 443 if ssl else 8112
+        self.url = f"http{'s' if ssl else ''}://{settings['host']}:{port}/json"
+        self.password = settings["password"] if "password" in settings else ""
+        if "torrent_directory" not in settings:
+            self.logger.error("Deluge requires a directory to check for torrent files")
+            raise ValueError()
+        self.torrent_dir = settings["torrent_directory"]
+        self.__connect()
+    
+    def __connect(self):
+        self.__login()
+        result = requests.post(self.url, json={"method": "web.get_host_status", "params": [self.host], "id": 1}, cookies=self.cookies, timeout=5)
+        j = result.json()
+        if "result" in j:
+            connected = j["result"] is not None and j["result"][1] == "Connected"
+            if not connected:
+                requests.post(self.url, json={"method": "web.connect", "params": [self.host], "id": 1}, cookies=self.cookies, timeout=5)
+
+    def __login(self):
+        if not self.connected():
+            body = {
+                "method": "auth.login",
+                "params": [self.password],
+                "id": 1
+            }
+            r = requests.post(self.url, json=body, cookies=self.cookies)
+            self.cookies = r.cookies
+    
+    def connected(self) -> bool:
+        result = requests.post(self.url, json={"method": "web.connected", "params": [], "id": 1}, cookies=self.cookies, timeout=5)
+        j = result.json()
+        if "result" in j and j["result"]:
+            if len(self.host) == 0:
+                result = requests.post(self.url, json={"method": "web.get_hosts", "params": [], "id": 1}, cookies=self.cookies, timeout=5)
+                j = result.json()
+                if "result" in j:
+                    self.host = j["result"][0][0]
+            return True
+        return False
+    
+
+
+    
+    def add(self, torrent_path: str, file_path: str) -> None:
+        file_path = mapPath(file_path, self.pathmaps)
+        dir = os.path.split(file_path)[0]
+        torrent_name = os.path.basename(torrent_path)
+
+        with open(torrent_path, "rb") as f:
+            r = requests.post(self.url.replace("/json", "/upload"), files={"file":(torrent_name, f, 'application/x-bittorrent')}, cookies=self.cookies, timeout=30)
+        j = r.json()
+        self.logger.debug(f"Deluge response: {j}")
+        if "success" in j and j["success"]:
+            torrent_path = j["files"][0]
+            body = {
+                "method": "web.add_torrents",
+                "params": [
+                    [{
+                        "path": torrent_path,
+                        "options": {
+                            "download_location": dir,
+                            "add_paused": True
+                        }
+                    }]
+                ],
+                "id": 1
+            }
+            try:
+                result = requests.post(self.url, json=body, cookies=self.cookies, timeout=10)
+                j = result.json()
+                self.logger.debug(f"Deluge response: {j}")
+                if "result" in j and j["result"][0][0]:
+                    self.logger.info("Torrent added to deluge")
+                else:
+                    self.logger.error(f"Torrent uploaded to Deluge but failed to start: {j['error'] if 'error' in j and j['error'] else 'Unknown error'}")
+            except requests.ReadTimeout:
+                self.logger.error("Failed to start Deluge torrent (does it already exist?)")
+        else:
+            self.logger.error("Failed to upload torrent to Deluge")

--- a/utils/torrent/deluge.py
+++ b/utils/torrent/deluge.py
@@ -89,6 +89,8 @@ class Deluge(TorrentClient):
                 j = result.json()
                 self.logger.debug(f"Deluge response: {j}")
                 if "result" in j and j["result"][0][0]:
+                    infohash = j["result"][0][1]
+                    self.recheck(infohash)
                     self.logger.info("Torrent added to deluge")
                 else:
                     self.logger.error(f"Torrent uploaded to Deluge but failed to start: {j['error'] if 'error' in j and j['error'] else 'Unknown error'}")
@@ -96,3 +98,13 @@ class Deluge(TorrentClient):
                 self.logger.error("Failed to start Deluge torrent (does it already exist?)")
         else:
             self.logger.error("Failed to upload torrent to Deluge")
+    
+    def recheck(self, infohash: str):
+        body = {
+            "method": "core.force_recheck",
+            "params": [
+                [ infohash ]
+            ],
+            "id": 1
+        }
+        requests.post(self.url, json=body, cookies=self.cookies, timeout=5)

--- a/utils/torrent/torrentclient.py
+++ b/utils/torrent/torrentclient.py
@@ -18,7 +18,7 @@ class TorrentClient:
             self.label = settings["label"]
 
     def add(self, torrent_path: str, file_path: str) -> None:
-        raise NotImplementedError
+        raise NotImplementedError()
 
 class RTorrent(TorrentClient):
     """Implements rtorrent's XMLRPC protocol to


### PR DESCRIPTION
This PR enables support for a deluge torrent client to be optionally configured. It supports:
* Authenticating with webui password
* Uploading torrent files from backend
* Mapping backend server paths to deluge paths for adding torrents

Not (yet?) supported:
* ~~"Force recheck" (planned)~~ Added
* Starting torrents (planned)

Not tested:
* Using deluge with no password
* Using deluge when multiple daemons are present
* Connecting via https
* Error handling only minimally tested
  * Should handle failure from adding duplicate torrents
  * Haven't tested all possible missing config options to ensure they are handled properly
  * Haven't tested case where session expires. This will likely fail and require restart of backend