### PR TITLE
Add support for qbittorrent web api

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -49,6 +49,23 @@ anon = false
 # [deluge.pathmaps]
 # "/stash-empornium/path" = "/deluge/path"
 
+# [qbittorrent]
+## Hostname or IP address
+# host = "127.0.0.1"
+## Port number
+# port = 8080
+## Set to true for https
+# ssl = false
+## Username for API
+# username = "admin"
+## Password for API
+# password = "adminadmin"
+## Equivalent to QBittorrent "category"
+# label = "stash-empornium"
+
+# [qbittorrent.pathmaps]
+# "/stash-empornium/path" = "/qbittorrent/path"
+
 #[redis]
 #host = "localhost"
 #port = 6379

--- a/utils/torrent/deluge.py
+++ b/utils/torrent/deluge.py
@@ -1,4 +1,3 @@
-from unittest import result
 from utils.torrent.torrentclient import TorrentClient
 from utils.paths import mapPath
 import os
@@ -9,7 +8,6 @@ class Deluge(TorrentClient):
     password: str
     cookies = None
     host: str = ""
-    torrent_dir: str
 
     def __init__(self, settings: dict) -> None:
         super().__init__(settings)
@@ -20,10 +18,6 @@ class Deluge(TorrentClient):
             port = 443 if ssl else 8112
         self.url = f"http{'s' if ssl else ''}://{settings['host']}:{port}/json"
         self.password = settings["password"] if "password" in settings else ""
-        if "torrent_directory" not in settings:
-            self.logger.error("Deluge requires a directory to check for torrent files")
-            raise ValueError()
-        self.torrent_dir = settings["torrent_directory"]
         self.__connect()
     
     def __connect(self):

--- a/utils/torrent/qbittorrent.py
+++ b/utils/torrent/qbittorrent.py
@@ -1,0 +1,65 @@
+from email import header
+from venv import logger
+from utils.torrent.torrentclient import TorrentClient
+from utils.paths import mapPath
+import os
+import requests
+
+class Qbittorrent(TorrentClient):
+    url: str
+    username: str
+    password: str
+    cookies = None
+    host: str = ""
+    torrent_dir: str
+    logged_in: bool = False
+
+    def __init__(self, settings: dict) -> None:
+        super().__init__(settings)
+        ssl = settings["ssl"] if "ssl" in settings else False
+        self.username = settings["username"]
+        if "port" in settings:
+            port = settings["port"]
+        else:
+            port = 443 if ssl else 8080
+        self.url = f"http{'s' if ssl else ''}://{settings['host']}:{port}/api/v2"
+        self.password = settings["password"] if "password" in settings else ""
+        self.__login()
+
+    def __login(self):
+        path = "/auth/login"
+        data = {
+            "username": self.username,
+            "password": self.password
+        }
+        r = requests.post(self.url+path, cookies=self.cookies, data=data)
+        self.cookies = r.cookies
+        self.logged_in = r.content.decode() == "Ok."
+        if not self.logged_in:
+            logger.error("Failed to login to qBittorrent")
+    
+    def add(self, torrent_path: str, file_path: str) -> None:
+        if not self.logged_in:
+            return
+        file_path = mapPath(file_path, self.pathmaps)
+        dir = os.path.split(file_path)[0]
+        torrent_name = os.path.basename(torrent_path)
+        path = "/torrents/add"
+        options = {
+            "paused": "true",
+            "savepath": dir
+        }
+        if len(self.label) > 0:
+            options["category"] = self.label
+        with open(torrent_path, "rb") as f:
+            r = requests.post(self.url+path, data=options, files={"torrents":(torrent_name, f, 'application/x-bittorrent')}, cookies=self.cookies, timeout=30)
+        if r.ok and r.content.decode() != "Fails.":
+            self.logger.info("Torrent added to qBittorrent")
+        else:
+            self.logger.error("Failed to add torrent to qBittorrent")
+    
+    def recheck(self, infohash: str):
+        if not self.logged_in:
+            return
+        path = "/torrents/recheck"
+        requests.get(self.url, params={"hashes": infohash}, cookies=self.cookies, timeout=5)


### PR DESCRIPTION
This PR enables adding torrents directly to an optional qBittorrent client. Torrents are added based on the file location on the backend, with an optional mapping from the backend server's file structure to the torrent client's file structure.