### PR TITLE
Include animated previews in upload

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -21,6 +21,10 @@ anon = false
 # media_directory = "/torrents"
 ## How to move files to media_directory. Must be 'copy', 'hardlink', or 'symlink'
 move_method = 'copy'
+## Upload a GIF preview of the scene
+use_preview = false
+## Use the preview GIF as the upload cover. Ignored if 'use_preview' is false
+animated_cover = true
 
 # [rtorrent]
 ## Hostname or IP address

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -59,7 +59,6 @@ findScene(id: "{}") {{
     paths {{
         screenshot
         preview
-        webp
     }}
     files {{
         id

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -106,6 +106,8 @@ class ConfigHandler(Singleton):
     config_file: str
     tag_config_file: str
     torrent_clients: list[TorrentClient] = []
+    animated_cover: bool
+    use_preview: bool
 
     def __init__(self):
         if not (self.initialized):
@@ -294,6 +296,8 @@ class ConfigHandler(Singleton):
                         conf["templates"][filename] = tmpConf["templates"][filename]  # type: ignore
 
         # TODO: better handling of unexpected values
+        self.use_preview = self.conf["backend"]["use_preview"] # type: ignore
+        self.animated_cover = self.conf["backend"]["animated_cover"] # type: ignore
         anon = self.conf["backend"]["anon"]  # type: ignore
         if anon is not None:
             assert isinstance(anon, bool)


### PR DESCRIPTION
This PR adds the ability to fetch the scene preview generated by stash, convert it to GIF, and upload it for inclusion in the presentation. Configuration settings are included to toggle between the animated GIF or the static scene cover as the presentation cover, or to disable this feature altogether.