### PR TITLE
Fix path mapping depending on TOML section name

### DIFF
--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,9 +1,8 @@
 def mapPath(path: str, pathmaps: dict[str,str]) -> str:
     # Apply remote path mappings
-    for remote in pathmaps:
+    for remote, local in pathmaps.items():
         if not path.startswith(remote):
             continue
-        local = pathmaps[remote]
         if remote[-1] != "/":
             remote += "/"
         if local[-1] != "/":


### PR DESCRIPTION
Fixes issue where path maps are not detected under the `file.maps` section of `config.toml`, but rather the `maps` key within the `file` section