### PR TITLE
Improve settings handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ The `media_directory` option specifies the parent directory where media files wi
 The script can be run with optional command line arguments, most of which override a corresponding configuration file option. These can be used to quickly change a setting without needing to modify the config file, such as for temporarily listening on a different port or saving torrent files in a different directory. Not all configuration options can currently be set via the command line. The available options are described in the script's help text below:
 
 ```text
-usage: emp_stash_fill.py [-h] [--configdir CONFIGDIR] [-t TORRENTDIR] [-p PORT] [-c] [-d] [-f] [-r] [--version] [--anon] [-q | -v | -l LEVEL] [--flush]
-                         [--no-cache | --overwrite]
+usage: emp_stash_fill.py [-h] [--configdir CONFIGDIR] [--version] [-q | -v | -l LEVEL] [--flush] [--no-cache | --overwrite]
 
 backend server for EMP Stash upload helper userscript
 
@@ -221,19 +220,7 @@ options:
   -h, --help            show this help message and exit
   --configdir CONFIGDIR
                         specify the directory containing configuration files
-  -t TORRENTDIR, --torrentdir TORRENTDIR
-                        specify the directory where .torrent files should be saved
-  -p PORT, --port PORT  port to listen on (default: 9932)
   --version             show program's version number and exit
-  --anon                upload anonymously
-
-Tags:
-  optional tag settings
-
-  -c                    include codec as tag
-  -d                    include date as tag
-  -f                    include framerate as tag
-  -r                    include resolution as tag
 
 Output:
   options for setting the log level

--- a/emp_stash_fill.py
+++ b/emp_stash_fill.py
@@ -254,7 +254,7 @@ def generate():
     elif ht >= 6143:
         resolution = "8K+"
 
-    if resolution is not None and config.tag_resolution:
+    if resolution is not None and config.get("metadata", "tag_resolution"):
         tags.add(resolution)
 
     ###########
@@ -487,16 +487,16 @@ def generate():
         for parent in tag["parents"]:
             tags.processTag(parent["name"])
 
-    if config.tag_codec and stash_file["video_codec"] is not None:
+    if config.get("metadata", "tag_codec") and stash_file["video_codec"] is not None:
         tags.add(stash_file["video_codec"])
 
-    if config.tag_codec and scene["date"] is not None and len(scene["date"]) > 0:
+    if config.get("metadata", "tag_date") and scene["date"] is not None and len(scene["date"]) > 0:
         year, month, day = scene["date"].split("-")
         tags.add(year)
         tags.add(f"{year}.{month}")
         tags.add(f"{year}.{month}.{day}")
 
-    if config.tag_framerate:
+    if config.get("metadata", "tag_framerate"):
         tags.add(str(round(stash_file["frame_rate"])) + ".fps")
 
     if scene["studio"] and scene["studio"]["url"] is not None:

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -88,19 +88,12 @@ class ConfigHandler(Singleton):
     default_template: str
     anon: bool
     port: int
-    rhost: str | None
-    rport: int
-    ssl: bool
     username: str
     password: str
     torrent_dirs: list[str]
     date_format: str
     stash_url: str
     template_dir: str
-    tag_codec: bool
-    tag_date: bool
-    tag_framerate: bool
-    tag_resolution: bool
     title_template: str
     template_names: dict[str, str]
     config_file: str
@@ -136,11 +129,6 @@ class ConfigHandler(Singleton):
             nargs=1,
         )
         parser.add_argument("-p", "--port", nargs=1, help="port to listen on (default: 9932)", type=int)
-        flags = parser.add_argument_group("Tags", "optional tag settings")
-        flags.add_argument("-c", action="store_true", help="include codec as tag")
-        flags.add_argument("-d", action="store_true", help="include date as tag")
-        flags.add_argument("-f", action="store_true", help="include framerate as tag")
-        flags.add_argument("-r", action="store_true", help="include resolution as tag")
         parser.add_argument("--version", action="version", version=f"stash-empornium {__version__}")
         parser.add_argument("--anon", action="store_true", help="upload anonymously")
         mutex = parser.add_argument_group("Output", "options for setting the log level").add_mutually_exclusive_group()
@@ -339,10 +327,6 @@ class ConfigHandler(Singleton):
             )
         )
         self.date_format = self.get("backend", "date_format", "%B %-d, %Y")  # type: ignore
-        self.tag_codec = self.args.c or self.get("metadata", "tag_codec", False)  # type: ignore
-        self.tag_date = self.args.d or self.get("metadata", "tag_date", False)  # type: ignore
-        self.tag_framerate = self.args.f or self.get("metadata", "tag_framerate", False)  # type: ignore
-        self.tag_resolution = self.args.r or self.get("metadata", "tag_resolution", False)  # type: ignore
 
         self.template_names = {}
         template_files = os.listdir(self.template_dir)


### PR DESCRIPTION
Simplify the `ConfigHandler` class by removing some unnecessary CLI options and not storing settings in class properties unnecessarily. This provides better support for modifying settings while the server is running, such as from the webui.