### PR TITLE
Torrent client connection check

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -114,4 +114,4 @@ tushy = "Tushy video page lookalike (by dickon)"
 ## url of your stash instance
 url = "http://localhost:9999"
 ## only needed if you set up authentication for stash
-#api_key = 123abc.xyz
+#api_key = "123abc.xyz"

--- a/utils/torrentclients.py
+++ b/utils/torrentclients.py
@@ -164,6 +164,9 @@ class Qbittorrent(TorrentClient):
     def _post(self, path: str, data: dict, files:dict|None = None, timeout: int = 5) -> requests.Response:
         r = requests.post(self.url+path, data=data, cookies=self.cookies, timeout=timeout, files=files)
         return r
+    
+    def connected(self) -> bool:
+        return self.logged_in
 
 
 class Deluge(TorrentClient):

--- a/utils/torrentclients.py
+++ b/utils/torrentclients.py
@@ -31,6 +31,9 @@ class TorrentClient:
     
     def resume(self, infohash: str):
         raise NotImplementedError()
+    
+    def connected(self) -> bool:
+        return True
 
 
 class RTorrent(TorrentClient):
@@ -85,6 +88,13 @@ class RTorrent(TorrentClient):
     
     def resume(self, infohash: str):
         self.server.d.start(infohash.upper())
+    
+    def connected(self) -> bool:
+        try:
+            self.server.system.listMethods()
+            return True
+        except:
+            return False
 
 
 class Qbittorrent(TorrentClient):


### PR DESCRIPTION
Adds a `connected` method to the `TorrentClient` class and implements it for rTorrent and qBittorrent. When configuring torrent clients, this method is called before adding the client to the list, and if connection was unsuccessful then the client is discarded and an error message is printed.