### PR TITLE
Add configuration for tag "display names"

### DIFF
--- a/utils/taghandler.py
+++ b/utils/taghandler.py
@@ -126,7 +126,7 @@ class TagHandler:
         else:
             self.tag_suggestions[tag] = empify(tag)
         for cat in s_tag.categories:
-            self.tag_sets[cat.name].add(tag)
+            self.tag_sets[cat.name].add(s_tag.display if s_tag.display else tag)
 
     def queryMaps(self, page=1, per_page=50):
         return StashTag.query.paginate(page=page, per_page=per_page)

--- a/webui/forms.py
+++ b/webui/forms.py
@@ -67,7 +67,10 @@ class BackendSettings(FlaskForm):
     example = StringField("Date Example:", render_kw={"readonly": True})
     title_template = StringField()
     anon = SwitchField("Upload Anonymously")
-    media_directory = StringField(validators=[Directory()], render_kw={"data-toggle": "tooltip", "title": "Where to save data for multi-file torrents"})
+    media_directory = StringField(
+        validators=[Directory()],
+        render_kw={"data-toggle": "tooltip", "title": "Where to save data for multi-file torrents"},
+    )
     move_method = SelectField(choices=["copy", "hardlink", "symlink"])  # type: ignore
     upload_gif = SwitchField("Upload Preview GIF")
     use_gif = SwitchField("Use GIF as Cover")
@@ -92,7 +95,9 @@ class TorrentSettings(FlaskForm):
     enable_form = SwitchField("Enable")
     host = StringField(validators=[ConditionallyRequired()])
     port = StringField(validators=[PortRange(), ConditionallyRequired()])
-    path = StringField(validators=[ConditionallyRequired(message="Please specify the API path (typically XMLRPC or RPC2)")])
+    path = StringField(
+        validators=[ConditionallyRequired(message="Please specify the API path (typically XMLRPC or RPC2)")]
+    )
     username = StringField(validators=[Optional()])
     password = PasswordField(validators=[Optional()])
     label = StringField()
@@ -136,8 +141,10 @@ class TorrentSettings(FlaskForm):
         self.validate()  # the errors on validation are cancelled in the line above
         return map
 
+
 class RTorrentSettings(TorrentSettings):
     pass
+
 
 class QBittorrentSettings(TorrentSettings):
     path = None
@@ -204,9 +211,32 @@ def getCategories():
 
 
 class TagAdvancedForm(FlaskForm):
-    ignored = SwitchField()
-    stash_tag = StringField()
-    emp_tags = StringField("EMP Tags")
+    ignored = SwitchField(
+        render_kw={
+            "data-toggle": "tooltip",
+            "title": "Don't include this tag in uploads",
+        }
+    )
+    stash_tag = StringField(
+        validators=[DataRequired()],
+        render_kw={
+            "data-toggle": "tooltip",
+            "title": "The name of the tag in your stash server",
+        },
+    )
+    display = StringField(
+        render_kw={
+            "data-toggle": "tooltip",
+            "title": "(Optional) How you want this tag to be displayed in your presentation",
+        }
+    )
+    emp_tags = StringField(
+        "EMP Tags",
+        render_kw={
+            "data-toggle": "tooltip",
+            "title": "(Optional) The tag(s) that this corresponds to on Empornium",
+        },
+    )
     categories = SelectMultipleField(choices=getCategories)  # type: ignore
     delete = SubmitField()
     save = SubmitField()
@@ -216,6 +246,7 @@ class TagAdvancedForm(FlaskForm):
             tag: StashTag = kwargs["tag"]
             kwargs["stash_tag"] = tag.tagname
             kwargs["emp_tags"] = " ".join([et.tagname for et in tag.emp_tags])
+            kwargs["display"] = tag.display
             kwargs["categories"] = [cat.name for cat in tag.categories]
             kwargs["ignored"] = tag.ignored
         super().__init__(*args, **kwargs)
@@ -244,7 +275,7 @@ class CategoryList(FlaskForm):
 
         # modify the data:
         updated_list = read_form_data["categories"]
-        if read_form_data["new_category"]:
+        if self.new_category.data:
             updated_list.append({})
         else:
             for i, row in enumerate(read_form_data["categories"]):
@@ -312,6 +343,7 @@ class FileMapForm(FlaskForm):
         self.__init__(formdata=None, **read_form_data)
         self.validate()  # the errors on validation are cancelled in the line above
         return map
+
 
 class DBImportExport(FlaskForm):
     export_database = SubmitField()

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -44,6 +44,7 @@ def tag(id):
     if form.validate_on_submit():
         if form.data["save"]:
             tag.ignored = form.data["ignored"]
+            tag.display = form.data["display"]
             tag.emp_tags.clear()
             for et in form.data["emp_tags"].split():
                 e_tag = get_or_create_no_commit(EmpTag, tagname=et)


### PR DESCRIPTION
Adds a field to advanced tag settings for an optional "display name" which allows the user to override how tags are displayed in presentations. Currently only affects category lists such as the default `sex_acts` category.

## Example:

Given the following tag database entry:

| Tag | Display | EMP Tags | Categories | Ignored |
| --- | --- | --- | --- | --- |
| Doggy | Doggy Style | doggy.style | sex_acts | false |

If a scene is tagged with `Doggy` in stash, then when an upload is generated for that scene, the `doggy.style` tag will be automatically added to it, and the phrase `Doggy Style` will be added to the `sex_acts` category list. That category list can then be applied in the presentation template to describe the contents of the scene.