### PR TITLE
Fix `enable` toggle disabling search bar instead of settings

### DIFF
--- a/static/scripts/forms.js
+++ b/static/scripts/forms.js
@@ -1,7 +1,7 @@
 try {
   let enabled = document.getElementById("enable_form");
   function toggle() {
-    const form = document.getElementsByTagName("form")[0];
+    const form = document.querySelector("#enable_form").parentElement.closest("form");
     for (el of form.querySelectorAll("input")) {
       if (el.id != "csrf_token" && el.id != "save" && el.id != enabled.id) {
         el.disabled = !enabled.checked;


### PR DESCRIPTION
The listener for the `enable` toggle on various forms had a bug where it would disable elements of the first form it found on the page, rather than the form containing the toggle itself.