### PR TITLE
Fix bug with multiple EMP domains

### DIFF
--- a/emp_stash_fill.user.js
+++ b/emp_stash_fill.user.js
@@ -145,7 +145,8 @@ function generate(data, callback) {
 
 function getTracker() {
     switch (location.hostname) {
-        case "www.empornium.is" || "www.empornium.sx":
+        case "www.empornium.is":
+        case "www.empornium.sx":
             return "EMP"
         case "femdomcult.org":
             return "FC"


### PR DESCRIPTION
Two EMP domains were merged using || which doesn't actually work in JS, they need to be separate cases with fallthrough. This was causing upload to crash when the tracker value was validated in the backend.