### PR TITLE
Allow user to specify contact sheet layout in config

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -9,9 +9,6 @@ torrent_directories = ["/torrents"]
 port = 9932
 ## jinja template for title
 ## see README.md for available variables
-## Uncomment this title for Whisparr compatibility
-#title_template = {{ studio|replace(' ', '')|replace('[^a-zA-Z0-9]', '') }} - {{ date.split('-')[0][-2:] }}.{{ date.split('-')[1] }}.{{ date.split('-')[2] }} - {{ title }} - {{performers|join(', ')}} - {{ codec }} - WEBDL - {{ resolution }}
-## Uncomment this title for Classic EMP template
 title_template = '{% if studio %}[{{studio}}] {% endif %}{{performers|join(", ")}}{% if performers %} - {% endif %}{{title}} {% if date %}({{date}}){% endif %}[{{resolution}}]'
 # Date format for title release - https://strftime.org/ for reference
 date_format = "%Y-%m-%d"
@@ -27,6 +24,8 @@ use_preview = false
 animated_cover = true
 ## Log level [DEBUG | INFO | WARNING | ERROR | CRITICAL]
 log_level = "INFO"
+## Dimensions of generated contact sheets
+contact_sheet_layout = "3x6"
 
 [hamster]
 ## This can be generated at https://hamster.is/settings/api

--- a/utils/imagehandler.py
+++ b/utils/imagehandler.py
@@ -238,7 +238,10 @@ class ImageHandler:
         """
         contact_sheet_file = tempfile.mkstemp(suffix="-contact.jpg")
         os.chmod(contact_sheet_file[1], 0o666)  # Ensures torrent client can read the file
-        cmd = ["vcsi", stash_file["path"], "-g", "3x6", "-o", contact_sheet_file[1]]
+
+        dimensions = conf.get("backend", "contact_sheet_layout", "3x6")
+
+        cmd = ["vcsi", stash_file["path"], "-g", dimensions, "-o", contact_sheet_file[1]]
         logger.info("Generating contact sheet")
         contact_sheet_remote_url = self.get_images(stash_file["id"], "contact", host)[0]
         if contact_sheet_remote_url is None or screens_dir is not None:


### PR DESCRIPTION
Closes #194. Allows the user to specify a custom string of the format `mxn` where `m` is the number of columns and `n` is the number of rows in the generated contact sheet. Default is `3x6`.