### PR TITLE
Ensure temp files are cleaned up after upload

### DIFF
--- a/utils/generator.py
+++ b/utils/generator.py
@@ -21,7 +21,7 @@ from flask import render_template, render_template_string
 from utils import imagehandler, taghandler
 from utils.confighandler import ConfigHandler, stash_headers, stash_query
 from utils.packs import link, read_gallery, get_torrent_directory
-from utils.paths import mapPath
+from utils.paths import mapPath, delete_temp_file
 
 MEDIA_INFO = shutil.which("mediainfo")
 FILENAME_VALID_CHARS = "-_.() %s%s" % (string.ascii_letters, string.digits)
@@ -499,6 +499,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
         if logo_url is None:
             logo_url = imagehandler.DEFAULT_IMAGES["studio"][img_host]
             logger.warning("Unable to upload studio image")
+        delete_temp_file(studio_img_file[1])
 
     if image_temp:
         shutil.rmtree(image_dir)  # type: ignore

--- a/utils/imagehandler.py
+++ b/utils/imagehandler.py
@@ -303,6 +303,8 @@ class ImageHandler:
         if len(digests) > 0:
             self.set_images(stash_file["id"], "screens", digests, host)
         logger.debug(f"Screens: {screens}")
+        for path in paths:
+            delete_temp_file(path)
         return screens
 
     def get_url(

--- a/utils/imagehandler.py
+++ b/utils/imagehandler.py
@@ -17,6 +17,7 @@ from requests import JSONDecodeError
 
 from utils.confighandler import ConfigHandler, stash_headers
 from utils.packs import prep_dir
+from utils.paths import delete_temp_file
 
 try:
     import redis
@@ -249,6 +250,7 @@ class ImageHandler:
             logger.debug(f"vcsi output:\n{process.stdout}")
             if process.returncode != 0:
                 logger.error("Couldn't generate contact sheet")
+                delete_temp_file(contact_sheet_file[1])
                 return None
 
             if screens_dir is not None:
@@ -257,13 +259,15 @@ class ImageHandler:
 
             logger.info("Uploading contact sheet")
             if contact_sheet_remote_url is None:
-                contact_sheet_remote_url, digest = self.get_url(contact_sheet_file[1], "image/jpeg", "jpg", host, default=None)
+                contact_sheet_remote_url, digest = self.get_url(contact_sheet_file[1], "image/jpeg", "jpg", host,
+                                                                default=None)
                 if contact_sheet_remote_url is None:
                     logger.error("Failed to upload contact sheet")
+                    delete_temp_file(contact_sheet_file[1])
                     return None
-                os.remove(contact_sheet_file[1])
                 if digest is not None:
                     self.set_images(stash_file["id"], "contact", [digest], host)
+        delete_temp_file(contact_sheet_file[1])
         return contact_sheet_remote_url
 
     def generate_screens(self, stash_file: dict[str, Any], host: str, num_frames: int = 10) -> Sequence[Optional[str]]:

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,4 +1,9 @@
-def mapPath(path: str, pathmaps: dict[str,str]) -> str:
+import os
+
+from loguru import logger
+
+
+def mapPath(path: str, pathmaps: dict[str, str]) -> str:
     # Apply remote path mappings
     for remote, local in pathmaps.items():
         if not path.startswith(remote):
@@ -10,3 +15,8 @@ def mapPath(path: str, pathmaps: dict[str,str]) -> str:
         path = local + path.removeprefix(remote)
         break
     return path
+
+
+def delete_temp_file(path: str):
+    logger.debug(f"Cleaning up temporary file {path}")
+    os.remove(path)


### PR DESCRIPTION
This PR fixes a bug where temp image files are almost always left in memory after being uploaded. This is a minor issue as the `/tmp` directory is generally emptied on reboot, but for servers with long uptime and large volumes of uploads this could result in a noticeable memory leak.