### PR TITLE
Improve handling of torrent file in server response stream

### DIFF
--- a/emp_stash_fill.py
+++ b/emp_stash_fill.py
@@ -13,7 +13,7 @@ from concurrent.futures import Future
 
 # external
 from flask import (Flask, Response, redirect, request, stream_with_context,
-                   url_for)
+                   url_for, send_from_directory)
 from flask_bootstrap import Bootstrap5
 from flask_migrate import Migrate
 from flask_wtf import CSRFProtect
@@ -127,6 +127,14 @@ def submit_job():
     j = request.get_json()
     job_id = generator.add_job(j)
     return json.dumps({"id": job_id})
+
+@app.route("/torrent/<path:filename>", methods=["GET"])
+@csrf.exempt
+def get_torrent(filename: str):
+    logger.debug(f"Got filename {filename}")
+    torrent_name = os.path.basename(filename)
+    logger.info(f"Serving {torrent_name}")
+    return send_from_directory(config.torrent_dirs[0], torrent_name, as_attachment=True)
 
 
 @app.route("/templates")

--- a/emp_stash_fill.user.js
+++ b/emp_stash_fill.user.js
@@ -397,44 +397,6 @@ async function popJob() {
                                                     }
                                                 }
                                             }
-
-                                            if ("file" in j.data) {
-                                                // Temporary for debugging. Replace the button each time
-                                                // so that we don't add multiple copies of the listener
-                                                // function to the same button.
-                                                let newBtn = submitBtn.cloneNode();
-                                                newBtn.disabled = false;
-                                                submitBtn.parentNode.replaceChild(newBtn, submitBtn);
-                                                newBtn.addEventListener("click", () => {
-                                                    newBtn.disabled = true;
-                                                    let formel = document.getElementById("upload_table");
-                                                    let formdata = new FormData(formel);
-                                                    formdata.set("file_input", b64toBlob(j.data.file.content, "application/x-bittorrent"), j.data.file.name);
-                                                    console.debug(formdata);
-                                                    const r = new XMLHttpRequest();
-                                                    r.onreadystatechange = function () {
-                                                        if (r.readyState === XMLHttpRequest.DONE) {
-                                                            document.open();
-                                                            document.write(r.responseText);
-                                                            document.close();
-                                                        }
-                                                    };
-                                                    r.open("POST", new URL("/upload.php", window.location).href);
-                                                    r.responseType = "text";
-                                                    r.send(formdata);
-
-                                                    GM_xmlhttpRequest({
-                                                        method: "POST",
-                                                        headers: {"Content-Type": "application/json"},
-                                                        url: new URL("/submit", BACKEND).href,
-                                                        responseType: "json",
-                                                        data: JSON.stringify({
-                                                            torrent_path: j.data.fill.torrent_path,
-                                                        }),
-                                                    });
-                                                });
-                                            }
-
                                             if ("suggestions" in j.data) {
                                                 let parent = document.getElementsByClassName("thin")[0];
 
@@ -655,6 +617,42 @@ async function popJob() {
                                                 parent.insertBefore(body, parent.children[7]);
                                                 parent.insertBefore(head, body);
                                             }
+                                        }
+                                        if ("file" in j.data) {
+                                            // Temporary for debugging. Replace the button each time
+                                            // so that we don't add multiple copies of the listener
+                                            // function to the same button.
+                                            let newBtn = submitBtn.cloneNode();
+                                            newBtn.disabled = false;
+                                            submitBtn.parentNode.replaceChild(newBtn, submitBtn);
+                                            newBtn.addEventListener("click", () => {
+                                                newBtn.disabled = true;
+                                                let formel = document.getElementById("upload_table");
+                                                let formdata = new FormData(formel);
+                                                formdata.set("file_input", b64toBlob(j.data.file.content, "application/x-bittorrent"), j.data.file.name);
+                                                console.debug(formdata);
+                                                const r = new XMLHttpRequest();
+                                                r.onreadystatechange = function () {
+                                                    if (r.readyState === XMLHttpRequest.DONE) {
+                                                        document.open();
+                                                        document.write(r.responseText);
+                                                        document.close();
+                                                    }
+                                                };
+                                                r.open("POST", new URL("/upload.php", window.location).href);
+                                                r.responseType = "text";
+                                                r.send(formdata);
+
+                                                GM_xmlhttpRequest({
+                                                    method: "POST",
+                                                    headers: {"Content-Type": "application/json"},
+                                                    url: new URL("/submit", BACKEND).href,
+                                                    responseType: "json",
+                                                    data: JSON.stringify({
+                                                        torrent_path: j.data.fill.torrent_path,
+                                                    }),
+                                                });
+                                            });
                                         }
                                     } else if (j.status === "error") {
                                         this.context.statusArea.innerHTML = "<span style='color: red;'>" + j.message + "</span>";

--- a/emp_stash_fill.user.js
+++ b/emp_stash_fill.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Stash upload helper
 // @namespace    http://tampermonkey.net/
-// @version      1.1.3
+// @version      1.2.0
 // @description  This script helps create an upload for empornium based on a scene from your local stash instance.
 // @author       bdbenim
 // @match        https://www.empornium.sx/upload.php*
@@ -30,6 +30,9 @@
 // ==/UserScript==
 
 // Changelog:
+// v1.2.0
+//  - Receive .torrent file separately from the rest of the submission to ensure template is always filled in
+//  - Fix a bug where the torrent is sometimes not started when submitting the upload form
 // v1.1.3
 //  - Add case for happyfappy.org as possible fix for wrong image host
 // v1.1.2
@@ -641,7 +644,6 @@ async function popJob() {
                                                 };
                                                 r.open("POST", new URL("/upload.php", window.location).href);
                                                 r.responseType = "text";
-                                                r.send(formdata);
 
                                                 GM_xmlhttpRequest({
                                                     method: "POST",
@@ -652,6 +654,7 @@ async function popJob() {
                                                         torrent_path: j.data.fill.torrent_path,
                                                     }),
                                                 });
+                                                r.send(formdata);
                                             });
                                         }
                                     } else if (j.status === "error") {

--- a/emp_stash_fill.user.js
+++ b/emp_stash_fill.user.js
@@ -215,6 +215,43 @@ async function popJob() {
     return job;
 }
 
+function attachFile(blob, filename, submitBtn) {
+    // Temporary for debugging. Replace the button each time
+    // so that we don't add multiple copies of the listener
+    // function to the same button.
+    let newBtn = submitBtn.cloneNode();
+    newBtn.disabled = false;
+    submitBtn.parentNode.replaceChild(newBtn, submitBtn);
+    newBtn.addEventListener("click", () => {
+        newBtn.disabled = true;
+        let formel = document.getElementById("upload_table");
+        let formdata = new FormData(formel);
+        formdata.set("file_input", blob, filename);
+        console.debug(formdata);
+        const r = new XMLHttpRequest();
+        r.onreadystatechange = function () {
+            if (r.readyState === XMLHttpRequest.DONE) {
+                document.open();
+                document.write(r.responseText);
+                document.close();
+            }
+        };
+        r.open("POST", new URL("/upload.php", window.location).href);
+        r.responseType = "text";
+
+        GM_xmlhttpRequest({
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            url: new URL("/submit", BACKEND).href,
+            responseType: "json",
+            data: JSON.stringify({
+                torrent_path: j.data.fill.torrent_path,
+            }),
+        });
+        r.send(formdata);
+    });
+}
+
 
 (function () {
     "use strict";
@@ -622,40 +659,7 @@ async function popJob() {
                                             }
                                         }
                                         if ("file" in j.data) {
-                                            // Temporary for debugging. Replace the button each time
-                                            // so that we don't add multiple copies of the listener
-                                            // function to the same button.
-                                            let newBtn = submitBtn.cloneNode();
-                                            newBtn.disabled = false;
-                                            submitBtn.parentNode.replaceChild(newBtn, submitBtn);
-                                            newBtn.addEventListener("click", () => {
-                                                newBtn.disabled = true;
-                                                let formel = document.getElementById("upload_table");
-                                                let formdata = new FormData(formel);
-                                                formdata.set("file_input", b64toBlob(j.data.file.content, "application/x-bittorrent"), j.data.file.name);
-                                                console.debug(formdata);
-                                                const r = new XMLHttpRequest();
-                                                r.onreadystatechange = function () {
-                                                    if (r.readyState === XMLHttpRequest.DONE) {
-                                                        document.open();
-                                                        document.write(r.responseText);
-                                                        document.close();
-                                                    }
-                                                };
-                                                r.open("POST", new URL("/upload.php", window.location).href);
-                                                r.responseType = "text";
-
-                                                GM_xmlhttpRequest({
-                                                    method: "POST",
-                                                    headers: {"Content-Type": "application/json"},
-                                                    url: new URL("/submit", BACKEND).href,
-                                                    responseType: "json",
-                                                    data: JSON.stringify({
-                                                        torrent_path: j.data.fill.torrent_path,
-                                                    }),
-                                                });
-                                                r.send(formdata);
-                                            });
+                                            attachFile(b64toBlob(j.data.file.content, "application/x-bittorrent"), j.data.file.name, submitBtn);
                                         }
                                     } else if (j.status === "error") {
                                         this.context.statusArea.innerHTML = "<span style='color: red;'>" + j.message + "</span>";

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -591,7 +591,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
     result = {
         "status": "success",
         "data": {
-            "message": "Done",
+            "message": "Almost done",
             "fill": {
                 "title": title,
                 "cover": preview_url
@@ -606,16 +606,27 @@ def generate(j: dict) -> Generator[str, None, str | None]:
         },
     }
 
+    logger.debug(f"Sending {len(tag_suggestions)} suggestions")
+    if len(tag_suggestions) > 0:
+        result["data"]["suggestions"] = dict(tag_suggestions)
+
+    yield json.dumps(result) + '\n'
+
+    result = {
+        "status": "success",
+        "data": {
+            "message": "Done",
+            "file": {}
+        }
+    }
+
     with open(torrent_paths[0], "rb") as f:
         result["data"]["file"] = {
             "name": os.path.basename(f.name),
             "content": str(base64.b64encode(f.read()).decode("ascii")),
         }
 
-    logger.debug(f"Sending {len(tag_suggestions)} suggestions")
-    if len(tag_suggestions) > 0:
-        result["data"]["suggestions"] = dict(tag_suggestions)
-
+    logger.debug(f"Sending torrent file {torrent_paths[0]}")
     yield json.dumps(result) + '\n'
 
     for client in config.torrent_clients:

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -591,7 +591,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
     result = {
         "status": "success",
         "data": {
-            "message": "Almost done",
+            "message": "Done",
             "fill": {
                 "title": title,
                 "cover": preview_url
@@ -610,23 +610,6 @@ def generate(j: dict) -> Generator[str, None, str | None]:
     if len(tag_suggestions) > 0:
         result["data"]["suggestions"] = dict(tag_suggestions)
 
-    yield json.dumps(result) + '\n'
-
-    result = {
-        "status": "success",
-        "data": {
-            "message": "Done",
-            "file": {}
-        }
-    }
-
-    with open(torrent_paths[0], "rb") as f:
-        result["data"]["file"] = {
-            "name": os.path.basename(f.name),
-            "content": str(base64.b64encode(f.read()).decode("ascii")),
-        }
-
-    logger.debug(f"Sending torrent file {torrent_paths[0]}")
     yield json.dumps(result) + '\n'
 
     for client in config.torrent_clients:


### PR DESCRIPTION
This PR closes #202 by separating the torrent file from the rest of the response from the server. A new `/torrent` endpoint is created that allows the client to download the torrent file by supplying its path, e.g. via `GET http://localhost:9932/torrent/name.torrent`

Additionally, a link is added to the instructions area for the user to download the torrent file directly.