### PR TITLE
Allow user to customize number of screenshots to generate

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -24,6 +24,8 @@ use_preview = false
 animated_cover = true
 ## Log level [DEBUG | INFO | WARNING | ERROR | CRITICAL]
 log_level = "INFO"
+
+[images]
 ## Dimensions of generated contact sheets
 contact_sheet_layout = "3x6"
 

--- a/default.toml
+++ b/default.toml
@@ -28,6 +28,7 @@ log_level = "INFO"
 [images]
 ## Dimensions of generated contact sheets
 contact_sheet_layout = "3x6"
+num_screens = 10
 
 #[hamster]
 ## This can be generated at https://hamster.is/settings/api

--- a/default.toml
+++ b/default.toml
@@ -18,17 +18,18 @@ anon = false
 # media_directory = "/torrents"
 ## How to move files to media_directory. Must be 'copy', 'hardlink', or 'symlink'
 move_method = "copy"
-## Upload a GIF preview of the scene
-use_preview = false
-## Use the preview GIF as the upload cover. Ignored if 'use_preview' is false
-animated_cover = true
 ## Log level [DEBUG | INFO | WARNING | ERROR | CRITICAL]
 log_level = "INFO"
 
 [images]
 ## Dimensions of generated contact sheets
 contact_sheet_layout = "3x6"
+## Number of screenshots to generate
 num_screens = 10
+## Upload a GIF preview of the scene
+use_preview = false
+## Use the preview GIF as the upload cover. Ignored if 'use_preview' is false
+animated_cover = true
 
 #[hamster]
 ## This can be generated at https://hamster.is/settings/api

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -448,6 +448,8 @@ class ConfigHandler(Singleton):
     def migrate(self):
         renamed_settings = {
             "backend.contact_sheet_layout" : "images.contact_sheet_layout",
+            "backend.use_preview": "images.use_preview",
+            "backend.animated_cover": "images.animated_cover",
         }
         for key in renamed_settings.keys():
             logger.debug(f"Migrating {key} to {renamed_settings[key]}")

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -450,6 +450,7 @@ class ConfigHandler(Singleton):
             "backend.contact_sheet_layout" : "images.contact_sheet_layout",
             "backend.use_preview": "images.use_preview",
             "backend.animated_cover": "images.animated_cover",
+            "backend.save_images": "images.save_images",
         }
         for key in renamed_settings.keys():
             logger.debug(f"Migrating {key} to {renamed_settings[key]}")
@@ -461,5 +462,4 @@ class ConfigHandler(Singleton):
                 self.conf[new_section][new_setting] = self.conf[section][setting]
                 self.delete(section, setting)
                 logger.warning("Migrated setting {} to {}".format(key, renamed_settings[key]))
-        self.update_file()
 

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -227,6 +227,7 @@ class ConfigHandler(Singleton):
             try:
                 with open(self.config_file) as f:
                     self.conf = tomlkit.load(f)
+                    self.migrate()
             except Exception as e:
                 logger.critical(f"Failed to read config file: {e}")
                 exit(1)
@@ -285,6 +286,7 @@ class ConfigHandler(Singleton):
         except Exception as e:
             logger.error(f"Failed to read tag config file: {e}")
         try:
+            # TODO warn about extra settings
             Config.model_validate(self.conf)
             self.backup_config()
             self.update_file()
@@ -442,3 +444,20 @@ class ConfigHandler(Singleton):
 
     def __getitem__(self, key: str):
         return self.conf.__getitem__(key) if self.conf.__contains__(key) else self.tag_conf.__getitem__(key)
+
+    def migrate(self):
+        renamed_settings = {
+            "backend.contact_sheet_layout" : "images.contact_sheet_layout",
+        }
+        for key in renamed_settings.keys():
+            logger.debug(f"Migrating {key} to {renamed_settings[key]}")
+            section, setting = key.split(".", 1)
+            new_section, new_setting = renamed_settings[key].split(".", 1)
+            if section in self.conf and setting in self.conf[section]:
+                if new_section not in self.conf:
+                    self.conf[new_section] = tomlkit.table()
+                self.conf[new_section][new_setting] = self.conf[section][setting]
+                self.delete(section, setting)
+                logger.warning("Migrated setting {} to {}".format(key, renamed_settings[key]))
+        self.update_file()
+

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -381,7 +381,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
 
     if gen_screens:
         screens_urls = images.generate_screens(stash_file=stash_file,
-                                               host=img_host)  # TODO customize number of screens from config
+                                               host=img_host)
         if screens_urls is None or None in screens_urls:
             yield error("Failed to generate screens")
             return

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -297,7 +297,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
     preview_send: Connection
     preview_recv, preview_send = mp.Pipe(False)
     preview_proc = mp.Process(target=images.process_preview, args=(preview_send, scene, img_host))
-    if config.get("backend", "use_preview", False):
+    if config.get("images", "use_preview", False):
         preview_proc.start()
     # del preview_send  # Ensures connection can be automatically closed if garbage collected
 
@@ -561,7 +561,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
     }
 
     preview_url = None
-    if config.get("backend", "use_preview", False):
+    if config.get("images", "use_preview", False):
         preview_proc.join(timeout=60)
         try:
             preview_proc.close()
@@ -596,7 +596,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
             "fill": {
                 "title": title,
                 "cover": preview_url
-                if preview_url and config.get("backend", "animated_cover", False)
+                if preview_url and config.get("images", "animated_cover", False)
                 else cover_remote_url,
                 "tags": " ".join(tags.tags),
                 "description": description,

--- a/utils/imagehandler.py
+++ b/utils/imagehandler.py
@@ -47,7 +47,7 @@ conf = ConfigHandler()
 
 
 def save_failed_upload(path: str) -> None:
-    dir_name: str | None = conf.get("backend", "save_images")
+    dir_name: str | None = conf.get("images", "save_images")
     if dir_name is not None:
         prep_dir(dir_name)
         filename = os.path.basename(path)

--- a/utils/imagehandler.py
+++ b/utils/imagehandler.py
@@ -270,7 +270,10 @@ class ImageHandler:
         delete_temp_file(contact_sheet_file[1])
         return contact_sheet_remote_url
 
-    def generate_screens(self, stash_file: dict[str, Any], host: str, num_frames: int = 10) -> Sequence[Optional[str]]:
+    def generate_screens(self, stash_file: dict[str, Any], host: str, num_frames: int = 0) -> Sequence[Optional[str]]:
+        if num_frames == 0:
+            num_frames = conf.get("images", "num_screens", 10)
+
         screens = self.get_images(stash_file["id"], "screens", host)
         if len(screens) > 0 and None not in screens:
             return screens

--- a/utils/imagehandler.py
+++ b/utils/imagehandler.py
@@ -240,7 +240,7 @@ class ImageHandler:
         contact_sheet_file = tempfile.mkstemp(suffix="-contact.jpg")
         os.chmod(contact_sheet_file[1], 0o666)  # Ensures torrent client can read the file
 
-        dimensions = conf.get("backend", "contact_sheet_layout", "3x6")
+        dimensions = conf.get("images", "contact_sheet_layout", "3x6")
 
         cmd = ["vcsi", stash_file["path"], "-g", dimensions, "-o", contact_sheet_file[1]]
         logger.info("Generating contact sheet")

--- a/utils/models.py
+++ b/utils/models.py
@@ -1,7 +1,8 @@
 import re
 from typing import Optional, Literal, Annotated, TypeAlias
 
-from pydantic import BaseModel, Field, model_validator, BeforeValidator, AfterValidator
+from pydantic import BaseModel, Field, model_validator, BeforeValidator, AfterValidator, PositiveInt
+
 
 def not_empty(s: str) -> str:
     if s.strip() == "":
@@ -28,11 +29,14 @@ class BackendConfig(BaseModel):
     anon: bool = False
     media_directory: Optional[str] = None
     move_method: MoveMethod = "copy"
+    log_level: LogLevel = "INFO"
+    save_images: Optional[str] = None
+
+class ImageConfig(BaseModel):
     use_preview: bool = False
     animated_cover: bool = True
-    log_level: LogLevel = "INFO"
-    contact_sheet_layout: Annotated[str, AfterValidator(validate_layout_str)] = "3x6"
-    save_images: Optional[str] = None
+    widthcontact_sheet_layout: Annotated[str, AfterValidator(validate_layout_str)] = "3x6"
+    num_screens: PositiveInt
 
 class HamsterConfig(BaseModel):
     api_key: ApiKey
@@ -88,6 +92,7 @@ class StashConfig(BaseModel):
 
 class Config(BaseModel):
     backend: BackendConfig
+    images: ImageConfig
     hamster: Optional[HamsterConfig] = None
     rtorrent: Optional[RTorrentConfig] = None
     deluge: Optional[DelugeConfig] = None

--- a/webui/forms.py
+++ b/webui/forms.py
@@ -9,7 +9,7 @@ from wtforms import (
     StringField,
     SubmitField,
     URLField,
-    SelectMultipleField,
+    SelectMultipleField, IntegerField,
 )
 from wtforms.validators import URL, DataRequired, Optional
 from wtforms.widgets import Input, PasswordInput
@@ -72,14 +72,18 @@ class BackendSettings(FlaskForm):
         render_kw={"data-toggle": "tooltip", "title": "Where to save data for multi-file torrents"},
     )
     move_method = SelectField(choices=["copy", "hardlink", "symlink"])  # type: ignore
-    upload_gif = SwitchField("Upload Preview GIF")
-    use_gif = SwitchField("Use GIF as Cover")
     tag_codec = SwitchField()
     tag_date = SwitchField()
     tag_framerate = SwitchField()
     tag_resolution = SwitchField()
     save = SubmitField()
 
+class ImageSettings(FlaskForm):
+    upload_gif = SwitchField("Upload Preview GIF")
+    use_gif = SwitchField("Use GIF as Cover")
+    contact_sheet_layout = StringField()
+    num_screens = IntegerField()
+    save = SubmitField()
 
 class RedisSettings(FlaskForm):
     enable_form = SwitchField("Use Redis")

--- a/webui/forms.py
+++ b/webui/forms.py
@@ -11,7 +11,7 @@ from wtforms import (
     URLField,
     SelectMultipleField, IntegerField,
 )
-from wtforms.validators import URL, DataRequired, Optional
+from wtforms.validators import URL, DataRequired, Optional, NumberRange
 from wtforms.widgets import Input, PasswordInput
 
 from utils.db import StashTag, Category
@@ -82,7 +82,7 @@ class ImageSettings(FlaskForm):
     upload_gif = SwitchField("Upload Preview GIF")
     use_gif = SwitchField("Use GIF as Cover")
     contact_sheet_layout = StringField()
-    num_screens = IntegerField()
+    num_screens = IntegerField(validators=[NumberRange(min=1.0)])
     save = SubmitField()
 
 class RedisSettings(FlaskForm):

--- a/webui/templates/navbar.html
+++ b/webui/templates/navbar.html
@@ -40,6 +40,10 @@
                      href="{{ url_for('settings_page.settings', page='files') }}">Files</a>
                 </li>
                 <li>
+                  <a class="dropdown-item"
+                     href="{{ url_for('settings_page.settings', page='images') }}">Images</a>
+                </li>
+                <li>
                   <hr class="dropdown-divider" />
                 </li>
                   <li>

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -14,7 +14,7 @@ from webui.forms import (
     SearchForm,
     FileMapForm,
     TorrentSettings,
-    DBImportExport, HamsterForm
+    DBImportExport, HamsterForm, ImageSettings
 )
 
 from utils.confighandler import ConfigHandler
@@ -181,12 +181,18 @@ def settings(page):
                 move_method=conf.get(page, "move_method", "copy"),
                 anon=conf.get(page, "anon", False),
                 choices=[opt for opt in conf["templates"]],  # type: ignore
-                upload_gif=conf.get(page, "use_preview", False),
-                use_gif=conf.get(page, "animated_cover", False),
                 tag_codec = conf.get("metadata", "tag_codec", False),
                 tag_date = conf.get("metadata", "tag_date", False),
                 tag_framerate = conf.get("metadata", "tag_framerate", False),
                 tag_resolution = conf.get("metadata", "tag_resolution", False),
+            )
+        case "images":
+            template_context["settings_option"] = "your image"
+            form = ImageSettings(
+                upload_gif=conf.get(page, "use_preview", False),
+                use_gif=conf.get(page, "animated_cover", False),
+                contact_sheet_layout=conf.get(page, "contact_sheet_layout", ""),
+                num_screens=conf.get(page, "num_screens", 10),
             )
         case "stash":
             template_context["settings_option"] = "your stash server"
@@ -290,6 +296,11 @@ def settings(page):
                 conf.set(page, "anon", form.data["anon"])
                 # Show updated title example:
                 form.title_example.data = render_template_string(form.title_template.data, **DUMMY_CONTEXT)
+            case "images":
+                conf.set(page, "upload_gif", form.data["upload_gif"])
+                conf.set(page, "use_gif", form.data["use_gif"])
+                conf.set(page, "contact_sheet_layout", form.data["contact_sheet_layout"])
+                conf.set(page, "num_screens", form.data["num_screens"])
             case "stash":
                 conf.set(page, "url", form.data["url"])
                 if form.data["api_key"]:

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -187,7 +187,7 @@ def settings(page):
                 tag_resolution = conf.get("metadata", "tag_resolution", False),
             )
         case "images":
-            template_context["settings_option"] = "your image"
+            template_context["settings_option"] = "your images"
             form = ImageSettings(
                 upload_gif=conf.get(page, "use_preview", False),
                 use_gif=conf.get(page, "animated_cover", False),


### PR DESCRIPTION
This PR introduces a new config section called `images` and moves image-related settings into it, including a new `num_screens` setting for the number of screenshots to generate.

Additionally, the `ConfigHandler` now has the ability to migrate config options that change, such as from renaming or being moved to a new config section, allowing this update to not break users' configs.