### PR TITLE
Change path mapping to support Windows-style paths

### DIFF
--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,60 @@
+import unittest
+from pathlib import PureWindowsPath
+
+from utils import paths
+
+path_maps = {
+    "/data/media": "/mnt/share/data/media",         # POSIX->POSIX
+    "/data/videos/": "/mnt/share/data/media",       # Trailing slash
+    "Z:\\data\\media": "/mnt/share/data/media",     # Windows->POSIX
+    "/data/Windows/media": "Z:\\data\\media",       # POSIX->Windows
+    "X:\\data\\Windows\\media": "Y:\\data\\media",  # Windows->Windows
+}
+
+class MyTestCase(unittest.TestCase):
+    def test_posix_mapping(self):
+        remote = "/data/media/scene.mp4"
+        expected = "/mnt/share/data/media/scene.mp4"
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+    def test_trailing_slash(self):
+        remote = "/data/videos/scene.mp4"
+        expected = "/mnt/share/data/media/scene.mp4"
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+    def test_posix_nested_mapping(self):
+        remote = "/data/media/some/directories/scene.mp4"
+        expected = "/mnt/share/data/media/some/directories/scene.mp4"
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+    def test_windows_posix_mapping(self):
+        remote = "Z:\\data\\media\\scene.mp4"
+        expected = "/mnt/share/data/media/scene.mp4"
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+    def test_windows_posix_nested_mapping(self):
+        remote = "Z:\\data\\media\\some\\directories\\scene.mp4"
+        expected = "/mnt/share/data/media/some/directories/scene.mp4"
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+    def test_posix_windows_mapping(self):
+        remote = "/data/Windows/media/scene.mp4"
+        expected = str(paths.normalize_path("Z:\\data\\media\\scene.mp4")) # Required for test to pass on linux
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+    def test_windows_mapping(self):
+        remote = "X:\\data\\Windows\\media\\scene.mp4"
+        expected = str(paths.normalize_path("Y:\\data\\media\\scene.mp4")) # Required for test to pass on linux
+        result = paths.remap_path(remote, path_maps)
+        self.assertEqual(expected, result)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/confighandler.py
+++ b/utils/confighandler.py
@@ -451,6 +451,7 @@ class ConfigHandler(Singleton):
             "backend.use_preview": "images.use_preview",
             "backend.animated_cover": "images.animated_cover",
             "backend.save_images": "images.save_images",
+            "file.maps" : "stash.pathmaps",
         }
         for key in renamed_settings.keys():
             logger.debug(f"Migrating {key} to {renamed_settings[key]}")

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -144,9 +144,10 @@ def generate(j: dict) -> Generator[str, None, str | None]:
         logger.debug(f"Checking path {f['path']}")
         if f["id"] == file_id:
             stash_file = f
-            maps = config.items("file.maps")
-            if not maps:
-                maps = config.get("file", "maps", {})
+            maps = config.get("stash", "pathmaps", {})
+            # maps = config.items("file.maps")
+            # if not maps:
+            #     maps = config.get("file", "maps", {})
             stash_file["path"] = remap_path(stash_file["path"], maps)  # type: ignore
             break
 

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -21,7 +21,7 @@ from flask import render_template, render_template_string
 from utils import imagehandler, taghandler
 from utils.confighandler import ConfigHandler, stash_headers, stash_query
 from utils.packs import link, read_gallery, get_torrent_directory
-from utils.paths import mapPath, delete_temp_file
+from utils.paths import remap_path, delete_temp_file
 
 MEDIA_INFO = shutil.which("mediainfo")
 FILENAME_VALID_CHARS = "-_.() %s%s" % (string.ascii_letters, string.digits)
@@ -147,7 +147,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
             maps = config.items("file.maps")
             if not maps:
                 maps = config.get("file", "maps", {})
-            stash_file["path"] = mapPath(stash_file["path"], maps)  # type: ignore
+            stash_file["path"] = remap_path(stash_file["path"], maps)  # type: ignore
             break
 
     if stash_file is None:
@@ -159,7 +159,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
         maps = config.items("file.maps")
         if not maps:
             maps = config.get("file", "maps", {})
-        stash_file["path"] = mapPath(stash_file["path"], maps)  # type: ignore
+        stash_file["path"] = remap_path(stash_file["path"], maps)  # type: ignore
         logger.debug(f"No exact file match, using {stash_file['path']}")
     elif not os.path.isfile(stash_file["path"]):
         yield error(f"Couldn't find file {stash_file['path']}")

--- a/utils/packs.py
+++ b/utils/packs.py
@@ -5,7 +5,7 @@ from typing import Any
 from zipfile import ZipFile
 
 from utils.confighandler import ConfigHandler
-from utils.paths import mapPath
+from utils.paths import remap_path
 
 conf = ConfigHandler()
 filetypes = tuple(s if s.startswith(".") else "." + s for s in
@@ -104,13 +104,13 @@ def read_gallery(scene: dict[str, Any]) -> tuple[str, str, bool] | None:
     temp = False
     gallery = scene["galleries"][0]
     if gallery["folder"]:
-        source_dir = mapPath(gallery["folder"]["path"], conf.items("file.maps"))
+        source_dir = remap_path(gallery["folder"]["path"], conf.items("file.maps"))
         os.makedirs(image_dir, exist_ok=True)
         for file in os.listdir(source_dir):
             link(os.path.join(source_dir, file), image_dir)
     elif gallery["files"]:
         temp = True
-        zip_file = mapPath(gallery["files"][0]["path"], conf.items("file.maps"))
+        zip_file = remap_path(gallery["files"][0]["path"], conf.items("file.maps"))
         source_dir = tempfile.mkdtemp()
         files = unzip(zip_file, source_dir)
         for file in files:

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,22 +1,37 @@
 import os
+from pathlib import Path, PureWindowsPath
 
 from loguru import logger
 
 
-def mapPath(path: str, pathmaps: dict[str, str]) -> str:
-    # Apply remote path mappings
-    for remote, local in pathmaps.items():
-        if not path.startswith(remote):
+def normalize_path(path: str) -> Path:
+    """Convert both Windows and POSIX paths to normalized Path objects."""
+    return Path(PureWindowsPath(path).as_posix())
+
+
+def remap_path(original_path: str, path_mappings: dict[str, str]) -> str:
+    """Remap paths using a dictionary of mount points"""
+    original_path = normalize_path(original_path)
+
+    for container_mount, host_mount in path_mappings.items():
+        container_mount = normalize_path(container_mount)
+        try:
+            relative_path = original_path.relative_to(container_mount)
+            return str(normalize_path(host_mount) / relative_path)
+        except ValueError:
+            # Path is not relative to this mount point
             continue
-        if remote[-1] != "/":
-            remote += "/"
-        if local[-1] != "/":
-            local += "/"
-        path = local + path.removeprefix(remote)
-        break
-    return path
+
+    # No mapping found, return original
+    return str(original_path)
 
 
-def delete_temp_file(path: str):
+def delete_temp_file(path: str | Path) -> None:
     logger.debug(f"Cleaning up temporary file {path}")
-    os.remove(path)
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        logger.debug(f"File {path} does not exist")
+        pass
+    except PermissionError:
+        logger.error(f"Could not delete temporary file {path}: Permission denied")

--- a/utils/torrentclients.py
+++ b/utils/torrentclients.py
@@ -7,7 +7,7 @@ from transmission_rpc import Client as TransmissionClient, TransmissionConnectEr
 from webencodings import labels
 
 from utils import bencoder
-from utils.paths import mapPath
+from utils.paths import remap_path
 
 
 class TorrentClient:
@@ -70,7 +70,7 @@ class RTorrent(TorrentClient):
 
     def add(self, torrent_path: str, file_path: str) -> None:
         super().add(torrent_path, file_path)
-        file_path = mapPath(file_path, self.pathmaps)
+        file_path = remap_path(file_path, self.pathmaps)
         dir = os.path.split(file_path)[0]
         logger.debug(f"Adding torrent {torrent_path} to directory {dir}")
         with open(torrent_path, "rb") as torrent:
@@ -134,7 +134,7 @@ class Qbittorrent(TorrentClient):
             return
         with open(torrent_path, "rb") as f:
             hash = bencoder.infohash(f.read())
-        file_path = mapPath(file_path, self.pathmaps)
+        file_path = remap_path(file_path, self.pathmaps)
         dir = os.path.split(file_path)[0]
         torrent_name = os.path.basename(torrent_path)
         options = {"paused": "true", "savepath": dir}
@@ -232,7 +232,7 @@ class Deluge(TorrentClient):
 
     def add(self, torrent_path: str, file_path: str) -> None:
         super().add(torrent_path, file_path)
-        file_path = mapPath(file_path, self.pathmaps)
+        file_path = remap_path(file_path, self.pathmaps)
         dir = os.path.split(file_path)[0]
         torrent_name = os.path.basename(torrent_path)
 
@@ -312,7 +312,7 @@ class Transmission(TorrentClient):
 
     def add(self, torrent_path: str, file_path: str) -> None:
         super().add(torrent_path, file_path)
-        file_path = mapPath(file_path, self.pathmaps)
+        file_path = remap_path(file_path, self.pathmaps)
         directory = os.path.split(file_path)[0]
 
         with open(torrent_path, "rb") as f:


### PR DESCRIPTION
This PR closes #145 by modifying the `remap_path` function to support both Windows and POSIX-style paths and allow converting between them. This should enable paths to be remapped in various configurations, such as when this application is running on Windows and stash is running in Docker.

Windows path mappings can be entered as follows:
```toml
[stash.pathmaps]
"C:\\path\\to\\media" = "/path/to/media"  # Back slashes must be escaped, but forward slashes can be entered as-is
```

Of note, this has only been tested with Stash on Windows and stash-empornium on Linux.