### PR TITLE
Fix: Properly parse audio bitrate output from ffprobe

### DIFF
--- a/utils/generator.py
+++ b/utils/generator.py
@@ -398,7 +398,7 @@ def generate(j: dict) -> Generator[str, None, str | None]:
     ]
     try:
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=True)
-        audio_bitrate = f"{int(proc.stdout) // 1000} kbps"
+        audio_bitrate = f"{int(proc.stdout.split('|')[0].strip()) // 1000} kbps"
 
     except subprocess.CalledProcessError:
         logger.warning("Unable to determine audio bitrate")


### PR DESCRIPTION
This PR fixes a bug in utils/generator.py where parsing the audio bitrate from ffprobe could fail if the output contained unexpected characters (e.g., 192000|).

Root cause:
The existing code assumed that proc.stdout would always be a clean integer string. In some cases, ffprobe outputs extra characters such as |, causing:

`ValueError: invalid literal for int() with base 10: '192000|'`

Fix:
We now split the output at the | character and strip whitespace before converting to an integer:

`audio_bitrate = f"{int(proc.stdout.split('|')[0].strip()) // 1000} kbps"`

Impact:

    Prevents crashes during torrent generation when processing files with unusual ffprobe output.

    No changes to expected behavior for normal ffprobe output.

Tested:

    Successfully generated a torrent for a problematic scene after applying the fix.

    Confirmed that standard scenes still work without issues.