### PR TITLE
Allow sanitizing log output

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -20,6 +20,8 @@ anon = false
 move_method = "copy"
 ## Log level [DEBUG | INFO | WARNING | ERROR | CRITICAL]
 log_level = "INFO"
+## Hide personal data such as announce URLs in logs
+sanitize_logs = true
 
 [images]
 ## Dimensions of generated contact sheets

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -655,7 +655,8 @@ def gen_torrent(
     ]
     logger.debug(f"Executing: {' '.join(cmd)}")
     process = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-    logger.debug(f"mktorrent output:\n{process.stdout}")
+    output = process.stdout
+    logger.debug(f"mktorrent output:\n{output}")
     if process.returncode != 0:
         tempdir.cleanup()
         logger.error("mktorrent failed, command: " + " ".join(cmd), "Couldn't generate torrent")

--- a/utils/generator.py
+++ b/utils/generator.py
@@ -656,6 +656,8 @@ def gen_torrent(
     logger.debug(f"Executing: {' '.join(cmd)}")
     process = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
     output = process.stdout
+    if config.get("backend", "sanitize_logs", False):
+        output = output.replace(announce_url, sanitize_announce_url(announce_url))
     logger.debug(f"mktorrent output:\n{output}")
     if process.returncode != 0:
         tempdir.cleanup()
@@ -671,3 +673,10 @@ def gen_torrent(
 def gen_media_info(pipe: Connection, path: str) -> None:
     cmd = [MEDIA_INFO, path]
     pipe.send(subprocess.check_output(cmd, text=True))
+
+
+def sanitize_announce_url(announce_url: str) -> str:
+    sanitized_announce = announce_url.split("/")
+    sanitized_announce[-2] = "x" * 32
+    sanitized_announce = "/".join(sanitized_announce)
+    return sanitized_announce

--- a/utils/models.py
+++ b/utils/models.py
@@ -31,6 +31,7 @@ class BackendConfig(BaseModel):
     move_method: MoveMethod = "copy"
     log_level: LogLevel = "INFO"
     save_images: Optional[str] = None
+    sanitize_logs: bool = True
 
 class ImageConfig(BaseModel):
     use_preview: bool = False

--- a/webui/forms.py
+++ b/webui/forms.py
@@ -52,6 +52,15 @@ class FileMap(Form):
     remote_path = StringField()
     delete = SubmitField()
 
+class MetadataSettings(Form):
+    tag_codec = SwitchField()
+    tag_date = SwitchField()
+    tag_framerate = SwitchField()
+    tag_resolution = SwitchField()
+
+class LogSettings(Form):
+    log_level = SelectField("Log Level (Requires Restart)", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
+    sanitize_logs = SwitchField("Sanitize Logs")
 
 class BackendSettings(FlaskForm):
     def __init__(self, **kwargs):
@@ -72,10 +81,8 @@ class BackendSettings(FlaskForm):
         render_kw={"data-toggle": "tooltip", "title": "Where to save data for multi-file torrents"},
     )
     move_method = SelectField(choices=["copy", "hardlink", "symlink"])  # type: ignore
-    tag_codec = SwitchField()
-    tag_date = SwitchField()
-    tag_framerate = SwitchField()
-    tag_resolution = SwitchField()
+    metadata_settings = FormField(MetadataSettings)
+    log_settings = FormField(LogSettings)
     save = SubmitField()
 
 class ImageSettings(FlaskForm):

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -14,7 +14,7 @@ from webui.forms import (
     SearchForm,
     FileMapForm,
     TorrentSettings,
-    DBImportExport, HamsterForm, ImageSettings
+    DBImportExport, HamsterForm, ImageSettings, MetadataSettings, LogSettings
 )
 
 from utils.confighandler import ConfigHandler
@@ -179,12 +179,18 @@ def settings(page):
                 title_example = render_template_string(title_template, **DUMMY_CONTEXT),
                 media_directory=conf.get(page, "media_directory", ""),
                 move_method=conf.get(page, "move_method", "copy"),
+                log_settings={
+                    "log_level": conf.get(page, "log_level", "INFO"),
+                    "sanitize_logs": conf.get(page, "sanitize_logs", True),
+                },
                 anon=conf.get(page, "anon", False),
                 choices=[opt for opt in conf["templates"]],  # type: ignore
-                tag_codec = conf.get("metadata", "tag_codec", False),
-                tag_date = conf.get("metadata", "tag_date", False),
-                tag_framerate = conf.get("metadata", "tag_framerate", False),
-                tag_resolution = conf.get("metadata", "tag_resolution", False),
+                metadata_settings={
+                    "tag_codec": conf.get("metadata", "tag_codec", False),
+                    "tag_date": conf.get("metadata", "tag_date", False),
+                    "tag_framerate": conf.get("metadata", "tag_framerate", False),
+                    "tag_resolution": conf.get("metadata", "tag_resolution", False),
+                },
             )
         case "images":
             template_context["settings_option"] = "your images"
@@ -284,15 +290,15 @@ def settings(page):
                 conf.set(page, "port", int(form.data["port"]))
                 conf.set(page, "title_template", form.data["title_template"])
                 conf.set(page, "date_format", form.data["date_format"])
-                conf.set(page, "use_preview", form.upload_gif.data)
-                conf.set(page, "animated_cover", form.use_gif.data)
-                conf.set("metadata", "tag_codec", form.tag_codec.data)
-                conf.set("metadata", "tag_date", form.tag_date.data)
-                conf.set("metadata", "tag_framerate", form.tag_framerate.data)
-                conf.set("metadata", "tag_resolution", form.tag_resolution.data)
+                conf.set("metadata", "tag_codec", form.data["metadata_settings"]["tag_codec"])
+                conf.set("metadata", "tag_date", form.data["metadata_settings"]["tag_date"])
+                conf.set("metadata", "tag_framerate", form.data["metadata_settings"]["tag_framerate"])
+                conf.set("metadata", "tag_resolution", form.data["metadata_settings"]["tag_resolution"])
                 if form.data["media_directory"]:
                     conf.set(page, "media_directory", form.data["media_directory"])
                 conf.set(page, "move_method", form.data["move_method"])
+                conf.set(page, "log_level", form.data["log_settings"]["log_level"])
+                conf.set(page, "sanitize_logs", form.data["log_settings"]["sanitize_logs"])
                 conf.set(page, "anon", form.data["anon"])
                 # Show updated title example:
                 form.title_example.data = render_template_string(form.title_template.data, **DUMMY_CONTEXT)


### PR DESCRIPTION
This PR adds a new `sanitize_logs` config option which, when set, attempts to sanitize the debug output of `mktorrent` to not show the user's full announce URL. This feature is experimental and has only been tested with EMP, but should work with any announce URL of the same format.