### PR TITLE
Add `mkbrr` support

### DIFF
--- a/utils/generator.py
+++ b/utils/generator.py
@@ -643,20 +643,36 @@ def gen_torrent(
     temp_path = os.path.join(tempdir.name, basename + ".torrent")
     torrent_paths = [os.path.join(d, stash_file["basename"] + ".torrent") for d in config.torrent_dirs]
     logger.debug(f"Saving torrent to {temp_path}")
-    cmd = [
-        "mktorrent",
-        "-l",
-        str(piece_size),
-        "-s",
-        source_for_announce(announce_url),
-        "-a",
-        announce_url,
-        "-p",
-        "-v",
-        "-o",
-        temp_path,
-        target,
-    ]
+    if shutil.which("mkbrr") is None:
+        cmd = [
+            "mktorrent",
+            "-l",
+            str(piece_size),
+            "-s",
+            source_for_announce(announce_url),
+            "-a",
+            announce_url,
+            "-p",
+            "-v",
+            "-o",
+            temp_path,
+            target,
+        ]
+    else:
+        cmd = [
+            "mkbrr",
+            "create",
+            "-l",
+            str(piece_size),
+            "-s",
+            source_for_announce(announce_url),
+            "-t",
+            announce_url,
+            "-v",
+            "-o",
+            temp_path,
+            target,
+        ]
     logger.debug(f"Executing: {' '.join(cmd)}")
     process = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
     output = process.stdout

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -39,7 +39,7 @@ def delete_temp_file(path: str | Path) -> None:
 
 def verify_scene(stash_file: dict) -> tuple[bool, str]:
     if not os.path.isfile(stash_file["path"]):
-        return False, "Couldn't find file {stash_file['path']}"
+        return False, f"Couldn't find file {stash_file['path']}"
 
     try:
         with open(stash_file["path"], "r") as f:


### PR DESCRIPTION
This PR adds support for using the `mkbrr` utility instead of `mktorrent` if it is installed. It is not yet added to the Docker image, so it will not actually be used yet for most users, but this functionality will be added in a future PR.

Improvements have also been made to how the output from `mktorrent` and `mkbrr` is handled, showing only the final state of progress bars in debug output rather than every incremental update.