### PR TITLE
use primary domain emparadise.rs, keep empornium.sx as valid alt domain

### DIFF
--- a/emp_stash_fill.user.js
+++ b/emp_stash_fill.user.js
@@ -4,6 +4,7 @@
 // @version      1.2.1
 // @description  This script helps create an upload for empornium based on a scene from your local stash instance.
 // @author       bdbenim
+// @match        https://emparadise.rs/upload.php*
 // @match        https://www.empornium.sx/upload.php*
 // @match        https://www.femdomcult.org/upload.php*
 // @match        https://femdomcult.org/upload.php*
@@ -76,7 +77,7 @@
 const BACKEND_DEFAULT = "http://localhost:9932";
 const STASH_DEFAULT = "http://localhost:9999";
 const STASH_API_KEY_DEFAULT = null;
-const EMPORNIUM_DEFAULT = "https://www.empornium.sx";
+const EMPORNIUM_DEFAULT = "https://emparadise.rs";
 
 const BACKEND = GM_getValue("backend_url", BACKEND_DEFAULT);
 const STASH = GM_getValue("stash_url", STASH_DEFAULT);
@@ -173,6 +174,7 @@ function generate(data, callback) {
 
 function getTracker() {
     switch (location.hostname) {
+        case "emparadise.rs":
         case "www.empornium.sx":
             return "EMP"
         case "femdomcult.org":
@@ -282,7 +284,7 @@ function attachFile(blob, filename) {
     let scriptInfo = GM_info;
     console.log("emp_stash_fill.user.js version " + scriptInfo.script.version);
 
-    // if (location.hostname === "www.empornium.is" || location.hostname === "www.empornium.sx") {
+    // if (location.hostname === "emparadise.rs" || location.hostname === "www.empornium.sx") {
     if (unsafeWindow.TRACKERS.includes(location.hostname)) {
         let tag_form_input = document.getElementById("taginput");
         if (!tag_form_input) {

--- a/resources/stash_library.user.js
+++ b/resources/stash_library.user.js
@@ -5,6 +5,7 @@
 // version 0.33.2
 
 const TRACKERS = [
+    "emparadise.rs",
     "www.empornium.sx",
     "femdomcult.org",
     "www.happyfappy.net",


### PR DESCRIPTION
This just follows the update at Emp on 19th April 2026:

> Fellow Pervs :emplove:
> 
> It is our pleasure to announce that our new domain is now ready: emparadise.rs
That is emparadise.rs, without www in front.
(You have to copy this URL manually, as just clicking it will forward you to .sx if you currently are on .sx. https://emparadise.rs/ )
>
> We intend to make Emparadise our main domain and use empornium.sx as our fallback domain. However, you are free to use whatever domain you prefer.
>
> This is not a rebrand of Empornium. We are still Empornium. However, due to how the internet is evolving, anything with "porn" in the name can cause issues nowadays. This is why we chose this safe although lame route. Keeping the smut strictly behind the login.

New primary domain is `emparadise.rs`
Existing domain is now the alternative domain `www.empornium.sx`